### PR TITLE
Fix leak of dir_monitor_impl of inotify implementation

### DIFF
--- a/include/inotify/dir_monitor_impl.hpp
+++ b/include/inotify/dir_monitor_impl.hpp
@@ -30,9 +30,10 @@ class dir_monitor_impl :
 public: 
     dir_monitor_impl() 
         : fd_(init_fd()), 
-        stream_descriptor_(inotify_io_service_, fd_), 
-        inotify_work_(new boost::asio::io_service::work(inotify_io_service_)), 
-        inotify_work_thread_(boost::bind(&boost::asio::io_service::run, &inotify_io_service_)), 
+        inotify_io_service_(new boost::asio::io_service()),
+        stream_descriptor_(new boost::asio::posix::stream_descriptor(*inotify_io_service_, fd_)),
+        inotify_work_(new boost::asio::io_service::work(*inotify_io_service_)),
+        inotify_work_thread_(boost::bind(&boost::asio::io_service::run, inotify_io_service_.get())),
         run_(true) 
     { 
     }
@@ -81,8 +82,10 @@ public:
     void destroy() 
     { 
         inotify_work_.reset(); 
-        inotify_io_service_.stop(); 
+        stream_descriptor_.reset();
+        inotify_io_service_->stop();
         inotify_work_thread_.join(); 
+        inotify_io_service_.reset();
 
         boost::unique_lock<boost::mutex> lock(events_mutex_); 
         run_ = false; 
@@ -131,7 +134,7 @@ private:
 public: 
     void begin_read() 
     { 
-        stream_descriptor_.async_read_some(boost::asio::buffer(read_buffer_), 
+        stream_descriptor_->async_read_some(boost::asio::buffer(read_buffer_),
             boost::bind(&dir_monitor_impl::end_read, shared_from_this(), 
             boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred)); 
     } 
@@ -181,8 +184,8 @@ private:
     } 
 
     int fd_; 
-    boost::asio::io_service inotify_io_service_; 
-    boost::asio::posix::stream_descriptor stream_descriptor_; 
+    boost::scoped_ptr<boost::asio::io_service> inotify_io_service_;
+    boost::scoped_ptr<boost::asio::posix::stream_descriptor> stream_descriptor_;
     boost::scoped_ptr<boost::asio::io_service::work> inotify_work_; 
     boost::thread inotify_work_thread_; 
     boost::array<char, 4096> read_buffer_; 


### PR DESCRIPTION
Destroy inotify_io_service_ to release the reference to
the dir_monitor_impl added by asyc_read_some. Otherwise
dir_monitor_impl will never get deleted since it gets
refered by its member object inotify_io_service_.
